### PR TITLE
Bug fix: test report is not generated if the test result contains 2 s…

### DIFF
--- a/src/TestLogger/Extensions/XunitTestAdapter.cs
+++ b/src/TestLogger/Extensions/XunitTestAdapter.cs
@@ -17,7 +17,7 @@ namespace Spekt.TestLogger.Extensions
 
             // Process all the messages collected during the test run
             // If one ends with [SKIP], then the next message contains the skip reason.
-            var skippedTestNamesWithReason = new Dictionary<string, string>();
+            var skippedTestNamesWithReason = new Queue<(string testName, string skipReason)>();
             for (int i = 0; i < messages.Count; i++)
             {
                 string message = messages[i].Message;
@@ -35,13 +35,15 @@ namespace Spekt.TestLogger.Extensions
                 from = reasonMessage.IndexOf("]") + 1;
                 string reason = reasonMessage.Substring(from).Trim();
 
-                skippedTestNamesWithReason.Add(testName, reason);
+                skippedTestNamesWithReason.Enqueue((testName, reason));
             }
 
             foreach (var result in results)
             {
-                if (skippedTestNamesWithReason.TryGetValue(result.TestCaseDisplayName, out var skipReason))
+                if (result.Outcome == TestOutcome.Skipped)
                 {
+                    var skipReason = GetSkipReason(result.TestResultDisplayName);
+
                     // TODO: Defining a new category for now...
                     result.Messages.Add(new TestResultMessage("skipReason", skipReason));
                 }
@@ -60,6 +62,22 @@ namespace Spekt.TestLogger.Extensions
             }
 
             return transformedResults;
+
+            string GetSkipReason(string expectedTestName)
+            {
+                // assume the call order matches the order of the items in the queue
+                if (skippedTestNamesWithReason.Count > 0)
+                {
+                    var (testName, knownSkipReason) = skippedTestNamesWithReason.Dequeue();
+                    if (testName == expectedTestName)
+                    {
+                        return knownSkipReason;
+                    }
+                }
+
+                const string unknownSkipReason = "N/A";
+                return unknownSkipReason;
+            }
         }
     }
 }

--- a/src/TestLogger/TestLogger.csproj
+++ b/src/TestLogger/TestLogger.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…kipped test results having the same name